### PR TITLE
Fixed a bug

### DIFF
--- a/dist/screenshot-mosaic.js
+++ b/dist/screenshot-mosaic.js
@@ -168,9 +168,10 @@ mp.options.read_options(mosaicOptions, "screenshot-mosaic");
 function testDirectory(path) {
     var paths = new Pathing();
     var target = mp.utils.join_path(path, "_mosaic_screenshot_test.bin");
-    mp.utils.write_file("file://".concat(target), "THIS FILE IS CREATED BY MPV SCREENSHOT MOSAIC SCRIPT");
-    var isError = mp.last_error();
-    if (isError) {
+    try {
+        mp.utils.write_file("file://".concat(target), "THIS FILE IS CREATED BY MPV SCREENSHOT MOSAIC SCRIPT");
+    }
+    catch (error) {
         mp.msg.error("Could not write to directory: " + path);
         return false;
     }


### PR DESCRIPTION
Fixed the bug that the script unexpectedly exited and could not be re executed when the screenshot address in the MPV configuration was illegal