### PR TITLE
Fix crash when using paths starting with ~

### DIFF
--- a/dist/screenshot-mosaic.js
+++ b/dist/screenshot-mosaic.js
@@ -192,7 +192,7 @@ function getOutputDir() {
         var lastError = mp.last_error();
         if (!lastError && testDirectory(expandScreenDir)) {
             mp.msg.info("Using screenshot directory: " + expandScreenDir);
-            return paths.fixPath(screenDir);
+            return paths.fixPath(expandScreenDir);
         }
     }
     // Use mpv home directory as fallback

--- a/src/screenshot-mosaic.ts
+++ b/src/screenshot-mosaic.ts
@@ -217,7 +217,7 @@ function getOutputDir(): string {
         const lastError = mp.last_error();
         if (!lastError && testDirectory(expandScreenDir)) {
             mp.msg.info("Using screenshot directory: " + expandScreenDir);
-            return paths.fixPath(screenDir);
+            return paths.fixPath(expandScreenDir);
         }
     }
 


### PR DESCRIPTION
Fix crash when using paths starting with ~ ( like "~~desktop/" )