### PR TITLE
Fix annotation and directory processing

### DIFF
--- a/dist/screenshot-mosaic.js
+++ b/dist/screenshot-mosaic.js
@@ -155,6 +155,9 @@ var Pathing = /** @class */ (function () {
                 path = path.replace(/\//g, "\\");
             }
         }
+        if (path.indexOf("Program Files")) {
+            path = path.replace("Program Files", "Progra~1");
+        }
         return path;
     };
     return Pathing;

--- a/dist/screenshot-mosaic.js
+++ b/dist/screenshot-mosaic.js
@@ -348,37 +348,48 @@ function runAnnotation(fileName, videoWidth, videoHeight, duration, imgOutput, c
     }
     var annotateCmds = __spreadArray(__spreadArray([], annotateCmdsBase, true), [
         "convert",
+
         "-background",
         "white",
+
         "-pointsize",
         "40",
         "label:mpv Media Player",
         "-gravity",
         "northwest",
+
+        //add top margin
+        "-splice",
+        "0x10",
+
         "-pointsize",
         "16",
-        "-splice",
-        "5x0",
         "label:File Name: " + fileName + "",
         "-gravity",
         "northwest",
+
         "-pointsize",
         "16",
         "label:File Size: " + humanizeBytes(mp.get_property_number("file-size")) + "",
         "-gravity",
         "northwest",
-        "-splice",
-        "5x0",
+
+        "-pointsize",
+        "16",
         "label:Resolution: " + videoWidth + "x" + videoHeight + "",
         "-gravity",
         "northwest",
+
         "-pointsize",
         "16",
         "label:Duration: " + duration + "",
         "-gravity",
         "northwest",
+        
+        //add left margin
         "-splice",
-        "5x0",
+        "20x0",
+
         imgOutput,
         "-append",
         imgOutput,

--- a/src/screenshot-mosaic.ts
+++ b/src/screenshot-mosaic.ts
@@ -177,6 +177,9 @@ class Pathing {
                 path = path.replace(/\//g, "\\");
             }
         }
+        if (path.indexOf("Program Files")) {
+            path = path.replace("Program Files", "Progra~1");
+        }
         return path;
     }
 }

--- a/src/screenshot-mosaic.ts
+++ b/src/screenshot-mosaic.ts
@@ -394,37 +394,48 @@ function runAnnotation(
     const annotateCmds = [
         ...annotateCmdsBase,
         "convert",
+
         "-background",
         "white",
+
         "-pointsize",
         "40",
         "label:mpv Media Player",
         "-gravity",
         "northwest",
+
+        //add top margin
+        "-splice",
+        "0x10",
+
         "-pointsize",
         "16",
-        "-splice",
-        "5x0",
         "label:File Name: " + fileName + "",
         "-gravity",
         "northwest",
+
         "-pointsize",
         "16",
         "label:File Size: " + humanizeBytes(mp.get_property_number("file-size")) + "",
         "-gravity",
         "northwest",
-        "-splice",
-        "5x0",
+
+        "-pointsize",
+        "16",
         "label:Resolution: " + videoWidth + "x" + videoHeight + "",
         "-gravity",
         "northwest",
+
         "-pointsize",
         "16",
         "label:Duration: " + duration + "",
         "-gravity",
         "northwest",
+
+        //add left margin
         "-splice",
-        "5x0",
+        "20x0",
+
         imgOutput,
         "-append",
         imgOutput,


### PR DESCRIPTION
1.Fix the typesetting of the mosaic's annotation text
2.Fixed issue caused by Windows default installation directory containing space